### PR TITLE
Fix README.md markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 <h1 align="center">🤞🏽 vouch</h1>
+
 [![Build Status](https://travis-ci.org/chadian/vouch.svg?branch=master)](https://travis-ci.org/chadian/vouch)
 [![npm](https://img.shields.io/npm/v/vouch-promise.svg)](https://www.npmjs.com/package/vouch-promise)
 [![Commitizen friendly](https://img.shields.io/badge/commitizen-friendly-blue.svg)](http://commitizen.github.io/cz-cli/)


### PR DESCRIPTION
I suppose there needs to be a space between html markup and markdown for the markdown to be interpreted correctly.